### PR TITLE
feat(phase-1): complete Phase 1 — Basic Bookkeeping Closed-Loop

### DIFF
--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -1,8 +1,131 @@
-export default function VaultPage() {
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion } from "framer-motion";
+import { Database, Trash2, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { seedDatabase, clearSeedData, countSeedData } from "@/lib/seed";
+
+// ─── Dev Seed Panel (only rendered in development) ────────────────────────────
+function SeedPanel() {
+  const [seedCount, setSeedCount] = useState<number | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const refresh = async () => {
+    setSeedCount(await countSeedData());
+  };
+
+  useEffect(() => { refresh(); }, []);
+
+  const handleSeed = async () => {
+    setIsLoading(true);
+    setStatus(null);
+    const result = await seedDatabase();
+    if (result.skipped) {
+      setStatus(`已跳过：数据库中已有 ${seedCount} 条测试数据`);
+    } else {
+      setStatus(`已插入 ${result.inserted} 条测试数据`);
+    }
+    await refresh();
+    setIsLoading(false);
+  };
+
+  const handleClear = async () => {
+    setIsLoading(true);
+    setStatus(null);
+    const deleted = await clearSeedData();
+    setStatus(`已清除 ${deleted} 条测试数据`);
+    await refresh();
+    setIsLoading(false);
+  };
+
   return (
-    <div className="min-h-screen p-8">
-      <h1 className="text-3xl font-bold text-galleon-gold">🔒 金库</h1>
-      <p className="mt-4 text-ink-secondary">设置与数据管理将在这里显示</p>
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="p-5 border border-dashed border-galleon-gold/40 rounded-xl bg-galleon-gold/5 space-y-4"
+    >
+      <div className="flex items-center gap-2">
+        <Database className="h-4 w-4 text-galleon-gold" />
+        <h3 className="text-xs font-mono uppercase tracking-widest text-galleon-gold">
+          Dev · Seed Data
+        </h3>
+        <span className="ml-auto text-xs font-mono text-ink-tertiary">
+          {seedCount !== null ? `${seedCount} 条测试记录` : "…"}
+        </span>
+      </div>
+
+      <div className="flex gap-3">
+        <Button
+          onClick={handleSeed}
+          disabled={isLoading}
+          size="sm"
+          className="flex-1 bg-galleon-gold hover:bg-galleon-gold-dark text-white rounded-full"
+        >
+          <RefreshCw className={`h-4 w-4 mr-1.5 ${isLoading ? "animate-spin" : ""}`} />
+          导入 50 条测试数据
+        </Button>
+        <Button
+          onClick={handleClear}
+          disabled={isLoading || seedCount === 0}
+          variant="outline"
+          size="sm"
+          className="rounded-full text-spell-danger border-spell-danger/30 hover:bg-spell-danger/5 disabled:opacity-40"
+        >
+          <Trash2 className="h-4 w-4 mr-1.5" />
+          清除
+        </Button>
+      </div>
+
+      {status && (
+        <p className="text-xs text-ink-secondary font-body">{status}</p>
+      )}
+
+      <p className="text-[10px] text-ink-tertiary font-mono">
+        仅在开发模式下可见。测试数据以 __seed__ 标签标记，可单独清除。
+      </p>
+    </motion.div>
+  );
+}
+
+// ─── Vault Page ───────────────────────────────────────────────────────────────
+export default function VaultPage() {
+  const isDev = process.env.NODE_ENV === "development";
+
+  return (
+    <div className="min-h-screen pt-12 pb-24 px-6 md:px-12 lg:px-16">
+      <div className="mx-auto max-w-2xl space-y-8">
+        <header className="space-y-1">
+          <p className="font-mono text-[10px] uppercase tracking-widest text-ink-tertiary">
+            Vault
+          </p>
+          <h2 className="text-4xl font-bold font-display tracking-tight text-ink-primary dark:text-foreground">
+            金库
+          </h2>
+          <p className="text-sm text-ink-secondary font-body mt-2">
+            设置与数据管理
+          </p>
+        </header>
+
+        <section className="space-y-3">
+          <p className="text-[10px] font-mono uppercase tracking-widest text-ink-tertiary">
+            即将上线
+          </p>
+          <div className="p-5 border border-border/50 rounded-xl text-ink-tertiary text-sm font-body">
+            Gemini API Key 管理、数据导出、生物识别锁定等功能将在 Phase 5 上线。
+          </div>
+        </section>
+
+        {isDev && (
+          <section className="space-y-3">
+            <p className="text-[10px] font-mono uppercase tracking-widest text-ink-tertiary">
+              开发工具
+            </p>
+            <SeedPanel />
+          </section>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/lib/seed.ts
+++ b/src/lib/seed.ts
@@ -1,0 +1,127 @@
+// src/lib/seed.ts
+// Dev-only seed data — 50 realistic transactions spanning 30 days
+// Tagged with "__seed__" for selective clearing
+
+import { db } from "@/lib/db";
+import type { TransactionInput } from "@/types/transaction";
+
+const SEED_TAG = "__seed__";
+
+// Helper: date string N days ago
+function daysAgo(n: number): string {
+    const d = new Date();
+    d.setDate(d.getDate() - n);
+    return d.toISOString().slice(0, 10);
+}
+
+const SEED_TRANSACTIONS: TransactionInput[] = [
+    // ── 餐饮 (14 entries) ──────────────────────────────────────────────────────
+    { amount: 38, type: "expense", category: "餐饮", merchant: "星巴克", description: "星巴克 拿铁 38", date: daysAgo(0), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 25, type: "expense", category: "餐饮", merchant: "麦当劳", description: "麦当劳 套餐 25", date: daysAgo(1), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 32, type: "expense", category: "餐饮", merchant: "美团外卖", description: "美团外卖 外卖 32", date: daysAgo(1), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 268, type: "expense", category: "餐饮", merchant: "海底捞", description: "海底捞 火锅 268", date: daysAgo(3), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 19, type: "expense", category: "餐饮", merchant: "肯德基", description: "肯德基 早餐 19", date: daysAgo(4), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 28, type: "expense", category: "餐饮", merchant: "瑞幸咖啡", description: "瑞幸咖啡 大杯拿铁 28", date: daysAgo(5), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 45, type: "expense", category: "餐饮", merchant: "饿了么", description: "饿了么 午饭 45", date: daysAgo(6), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 12, type: "expense", category: "餐饮", merchant: "沙县小吃", description: "沙县小吃 12", date: daysAgo(8), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 88, type: "expense", category: "餐饮", merchant: "必胜客", description: "必胜客 披萨 88", date: daysAgo(10), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 15, type: "expense", category: "餐饮", merchant: "兰州拉面", description: "兰州拉面 午餐 15", date: daysAgo(12), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 36, type: "expense", category: "餐饮", merchant: "星巴克", description: "星巴克 美式 36", date: daysAgo(14), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 22, type: "expense", category: "餐饮", merchant: "美团外卖", description: "美团外卖 晚饭 22", date: daysAgo(16), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 55, type: "expense", category: "餐饮", merchant: "西贝莜面村", description: "西贝莜面村 55", date: daysAgo(20), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 18, type: "expense", category: "餐饮", merchant: "全家便利店", description: "全家便利店 便当 18", date: daysAgo(25), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+
+    // ── 交通 (7 entries) ──────────────────────────────────────────────────────
+    { amount: 28, type: "expense", category: "交通", merchant: "滴滴打车", description: "滴滴打车 28", date: daysAgo(0), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 6, type: "expense", category: "交通", merchant: "地铁", description: "地铁 6", date: daysAgo(2), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 156, type: "expense", category: "交通", merchant: "高铁", description: "高铁 上海-南京 156", date: daysAgo(7), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 320, type: "expense", category: "交通", merchant: "中国石化", description: "加油 320", date: daysAgo(9), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 3, type: "expense", category: "交通", merchant: "哈罗单车", description: "共享单车 3", date: daysAgo(11), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 35, type: "expense", category: "交通", merchant: "滴滴打车", description: "滴滴打车 深夜 35", date: daysAgo(17), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 8, type: "expense", category: "交通", merchant: "公交车", description: "公交车 8", date: daysAgo(22), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+
+    // ── 购物 (7 entries) ──────────────────────────────────────────────────────
+    { amount: 299, type: "expense", category: "购物", merchant: "淘宝", description: "淘宝 冬季外套 299", date: daysAgo(2), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 599, type: "expense", category: "购物", merchant: "京东", description: "京东 机械键盘 599", date: daysAgo(5), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 89, type: "expense", category: "购物", merchant: "超市", description: "超市 日用品 89", date: daysAgo(9), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 398, type: "expense", category: "购物", merchant: "优衣库", description: "优衣库 毛衣 398", date: daysAgo(13), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 129, type: "expense", category: "购物", merchant: "无印良品", description: "无印良品 收纳 129", date: daysAgo(18), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 45, type: "expense", category: "购物", merchant: "拼多多", description: "拼多多 零食 45", date: daysAgo(23), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 199, type: "expense", category: "购物", merchant: "ZARA", description: "ZARA 衬衫 199", date: daysAgo(28), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+
+    // ── 娱乐 (5 entries) ──────────────────────────────────────────────────────
+    { amount: 75, type: "expense", category: "娱乐", merchant: "电影院", description: "电影院 75", date: daysAgo(3), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 25, type: "expense", category: "娱乐", merchant: "网易云音乐", description: "网易云音乐 年会员 25", date: daysAgo(8), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 148, type: "expense", category: "娱乐", merchant: "KTV", description: "KTV 包厢 148", date: daysAgo(15), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 68, type: "expense", category: "娱乐", merchant: "Steam", description: "Steam 游戏 68", date: daysAgo(19), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 30, type: "expense", category: "娱乐", merchant: "B站大会员", description: "B站大会员 季度 30", date: daysAgo(26), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+
+    // ── 居住 (4 entries) ──────────────────────────────────────────────────────
+    { amount: 4500, type: "expense", category: "居住", merchant: "房东", description: "房租 月付 4500", date: daysAgo(1), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 68, type: "expense", category: "居住", merchant: "电力公司", description: "电费 68", date: daysAgo(6), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 32, type: "expense", category: "居住", merchant: "自来水公司", description: "水费 32", date: daysAgo(6), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 280, type: "expense", category: "居住", merchant: "物业", description: "物业费 280", date: daysAgo(20), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+
+    // ── 医疗 (3 entries) ──────────────────────────────────────────────────────
+    { amount: 85, type: "expense", category: "医疗", merchant: "药店", description: "感冒药 85", date: daysAgo(4), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 300, type: "expense", category: "医疗", merchant: "医院", description: "门诊挂号+检查 300", date: daysAgo(12), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 580, type: "expense", category: "医疗", merchant: "美年大健康", description: "年度体检 580", date: daysAgo(24), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+
+    // ── 教育 (3 entries) ──────────────────────────────────────────────────────
+    { amount: 199, type: "expense", category: "教育", merchant: "极客时间", description: "极客时间 专栏 199", date: daysAgo(7), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 89, type: "expense", category: "教育", merchant: "书店", description: "技术书籍 89", date: daysAgo(14), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 680, type: "expense", category: "教育", merchant: "得到", description: "得到 年度会员 680", date: daysAgo(27), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+
+    // ── 投资 (2 entries) ──────────────────────────────────────────────────────
+    { amount: 1000, type: "expense", category: "投资", merchant: "支付宝基金", description: "基金定投 1000", date: daysAgo(1), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 2000, type: "expense", category: "投资", merchant: "支付宝基金", description: "基金定投 2000", date: daysAgo(16), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+
+    // ── 收入 (3 entries) ──────────────────────────────────────────────────────
+    { amount: 18000, type: "income", category: "收入", merchant: "公司", description: "月薪 18000", date: daysAgo(0), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 3500, type: "income", category: "收入", merchant: "公司", description: "绩效奖金 3500", date: daysAgo(15), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 800, type: "income", category: "收入", merchant: "兼职", description: "兼职收入 800", date: daysAgo(22), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+
+    // ── 其他 (2 entries) ──────────────────────────────────────────────────────
+    { amount: 58, type: "expense", category: "其他", merchant: "理发店", description: "理发 58", date: daysAgo(10), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+    { amount: 12, type: "expense", category: "其他", merchant: "快递", description: "快递费 12", date: daysAgo(21), confidence: 1, needsReview: false, tags: [SEED_TAG] },
+];
+
+/** Insert all seed transactions. Skips if seed data already exists. */
+export async function seedDatabase(): Promise<{ inserted: number; skipped: boolean }> {
+    const existing = await db.transactions
+        .filter(tx => tx.tags?.includes(SEED_TAG))
+        .count();
+
+    if (existing > 0) {
+        return { inserted: 0, skipped: true };
+    }
+
+    const now = new Date().toISOString();
+    const records = SEED_TRANSACTIONS.map(tx => ({
+        ...tx,
+        subCategory: "",
+        aiReasoning: "Seed data",
+        createdAt: now,
+        updatedAt: now,
+    }));
+
+    await db.transactions.bulkAdd(records as never);
+    return { inserted: records.length, skipped: false };
+}
+
+/** Remove all seed transactions (tagged with __seed__). */
+export async function clearSeedData(): Promise<number> {
+    const ids = await db.transactions
+        .filter(tx => tx.tags?.includes(SEED_TAG))
+        .primaryKeys();
+
+    await db.transactions.bulkDelete(ids as number[]);
+    return ids.length;
+}
+
+/** Count existing seed transactions. */
+export async function countSeedData(): Promise<number> {
+    return db.transactions
+        .filter(tx => tx.tags?.includes(SEED_TAG))
+        .count();
+}


### PR DESCRIPTION
## Summary

Phase 1 全部 6 个 Step 实现完成，达成「输入 "咖啡 35" → 解析 → 存储 → 金币动画」的基础记账闭环。

### Step 1.1 — Data Schema (Dexie.js)
- `Transaction` 完整数据模型（含 `confidence`、`needsReview`、`source`、`subCategory`）
- Dexie v4，索引：`date / category / subCategory / type / createdAt`
- SQLite WASM 迁移钩子占位

### Step 1.2 — Category System
- 10 个预设分类（餐饮/交通/购物/娱乐/居住/医疗/教育/投资/收入/其他）
- `CategorySelector` / `CategorySelectorCompact` 组件

### Step 1.3 — Natural Language Parser
- `src/services/parser/localParser.ts`：零延迟本地解析，无 AI 依赖
- 200+ 商户词典（含中英文别名）
- 金额提取、日期识别（今天/昨天/前天）、收支判断、置信度评分

### Step 1.4 — Today Page (Core UI)
- GalleonInput：300ms debounce 解析预览 → Confirm → CoinDrop 动画
- Quick Tags 快捷标签 + 品牌选择器（咖啡品牌展开）
- 每日汇总卡片、交易列表（倒序）、空状态

### Step 1.5 — Transaction CRUD Hook
- `useTransactions`：`addTransaction` / `deleteTransaction` / `updateTransaction`
- 5 秒内相同金额+商户自动去重（`createdAt` 索引查询）
- 卡片 hover 显示删除按钮（硬删除）
- 点击卡片正文弹出编辑 Modal（金额/商户/日期/分类/收支类型）

### Step 1.6 — Seed Data Script
- `src/lib/seed.ts`：50 条真实感测试数据，覆盖全部 10 个分类，30 天跨度
- Vault 页 Dev Panel（仅 `NODE_ENV=development` 可见）：一键导入 / 清除 seed 数据

## Test plan

- [ ] 输入 "星巴克 35" → 预览显示商户/分类/置信度 → Confirm → 列表顶部出现 → CoinDrop 触发
- [ ] 输入 "工资 18000" → type 识别为 income → 收入色展示
- [ ] 输入 "昨天打车 28" → date 正确偏移 -1 天
- [ ] 5 秒内连续提交相同记录 → 第二次被拦截，显示重复提示
- [ ] 点击交易卡片 → 编辑 Modal 打开，修改后保存，列表响应式更新
- [ ] Hover 交易卡片 → 删除按钮出现，点击后记录消失
- [ ] Vault 页（dev）→ 导入 50 条测试数据 → Today 页列表填充 → 再次导入提示跳过 → 清除后归零
- [ ] 刷新页面，IndexedDB 数据持久化

🤖 Generated with [Claude Code](https://claude.com/claude-code)